### PR TITLE
falcon: move akmd daemon to device

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -43,4 +43,5 @@ lib/libchromatix_ar0543_preview.so
 lib/libchromatix_ar0543_snapshot.so
 
 # Sensors
+bin/akmd8963
 lib/hw/sensors.msm8226.so


### PR DESCRIPTION
Titan doesn't have akmd sensor so akmd daemon keeps starting and
that results in logcat spam & unnecessary memory/cpu usage.

Logcat:
I/AKMD2   (10705): AK8963 for Android v20111216(Library: v1.0.0.809)
started.
I/AKMD2   (10705): Debug: OFF
I/AKMD2   (10705): Debug level: 0
I/AKMD2   (10705): Output to: LOGD
E/AKMD2   (10705): AKD_InitDevice:54 open Error (No such file or directory).
I/AKMD2   (10705): AK8963/B for Android end (-2).

Change-Id: Ie62c63647b7e820dec210e8687c4e193be71096d